### PR TITLE
Feature: Add .ti file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 					"tm1 process"
 				],
 				"extensions": [
-					".pro"
+					".pro",
+					".ti"
 				],
 				"configuration": "./language-configuration.json"
 			}


### PR DESCRIPTION
The TM1 Git integration and other third-party tools use the .ti file extension for files that only contain the script parts Prolog, Metadata, Data and Epilog.

This change enable all the features for these files. 